### PR TITLE
Add support for Symfony 3.4/4.0

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,7 +9,7 @@
     </parameters>
 
     <services>
-        <service id="netpositive_discriminator_map" class="%netpositive_discriminator_map.class%">
+        <service id="netpositive_discriminator_map" class="%netpositive_discriminator_map.class%" public="true">
             <argument>%netpositive_discriminator_map.discriminator_map%</argument>
             <tag name="doctrine.event_listener" event="loadClassMetadata"/>
         </service>


### PR DESCRIPTION
The "netpositive_discriminator_map" service is private, getting it from the container is deprecated since Symfony 3.2 and will fail in 4.0. You should either make the service public, or stop using the container directly and use dependency injection instead.